### PR TITLE
refactor: new placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ go get github.com/cristalhq/builq
 var b builq.Builder
 b.Appendf("SELECT %s FROM %s", "foo, bar", "users")
 b.Appendf("WHERE active IS TRUE")
-b.Appendf("AND user_id = %a OR user = %a", 42, "root")
+b.Appendf("AND user_id = %$ OR user = %$", 42, "root")
 
 query, args, err := b.Build()
 if err != nil {

--- a/builq.go
+++ b/builq.go
@@ -1,21 +1,32 @@
 package builq
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
 
+// ErrDifferentPlaceholders is returned by [Builder.Build] when different
+// placeholders are used in a single query (e.g. WHERE foo = %$ AND bar = %?).
+var ErrDifferentPlaceholders = errors.New("builq: different placeholders must not be used")
+
 // Builder for SQL queries.
 type Builder struct {
-	query   strings.Builder
-	args    []any
-	counter int   // a counter for numbered placeholders ($1, $2, ...).
-	err     error // the first error occurred while building the query.
+	query        strings.Builder
+	args         []any
+	counter      int               // a counter for numbered placeholders ($1, $2, ...).
+	err          error             // the first error occurred while building the query.
+	placeholders map[rune]struct{} // a set of placeholders used to build the query.
 }
 
 func (b *Builder) Appendf(format string, args ...any) *Builder {
+	if b.placeholders == nil {
+		b.placeholders = make(map[rune]struct{})
+	}
+
+	// return earlier if there is already an error.
 	if b.err != nil {
-		return b // return earlier if there is already an error.
+		return b
 	}
 
 	wargs := make([]any, len(args))
@@ -30,6 +41,9 @@ func (b *Builder) Appendf(format string, args ...any) *Builder {
 }
 
 func (b *Builder) Build() (string, []any, error) {
+	if len(b.placeholders) > 1 {
+		return "", nil, ErrDifferentPlaceholders
+	}
 	return b.query.String(), b.args, b.err
 }
 
@@ -47,11 +61,13 @@ func (a *argument) Format(s fmt.State, v rune) {
 
 	case '$': // PostgreSQL
 		a.builder.args = append(a.builder.args, a.value)
+		a.builder.placeholders[v] = struct{}{}
 		a.builder.counter++
 		fmt.Fprintf(s, "$%d", a.builder.counter)
 
 	case '?': // MySQL/SQLite
 		a.builder.args = append(a.builder.args, a.value)
+		a.builder.placeholders[v] = struct{}{}
 		fmt.Fprint(s, "?")
 
 	default:

--- a/builq.go
+++ b/builq.go
@@ -12,18 +12,14 @@ var ErrDifferentPlaceholders = errors.New("builq: different placeholders must no
 
 // Builder for SQL queries.
 type Builder struct {
-	query        strings.Builder
-	args         []any
-	counter      int               // a counter for numbered placeholders ($1, $2, ...).
-	err          error             // the first error occurred while building the query.
-	placeholders map[rune]struct{} // a set of placeholders used to build the query.
+	query       strings.Builder
+	args        []any
+	err         error // the first error occurred while building the query.
+	counter     int   // a counter for numbered placeholders ($1, $2, ...).
+	placeholder rune  // a placeholder used to build the query.
 }
 
 func (b *Builder) Appendf(format string, args ...any) *Builder {
-	if b.placeholders == nil {
-		b.placeholders = make(map[rune]struct{})
-	}
-
 	// return earlier if there is already an error.
 	if b.err != nil {
 		return b
@@ -41,10 +37,17 @@ func (b *Builder) Appendf(format string, args ...any) *Builder {
 }
 
 func (b *Builder) Build() (string, []any, error) {
-	if len(b.placeholders) > 1 {
-		return "", nil, ErrDifferentPlaceholders
-	}
 	return b.query.String(), b.args, b.err
+}
+
+func (b *Builder) appendArg(arg any, placeholder rune) {
+	if b.placeholder == 0 {
+		b.placeholder = placeholder
+	}
+	if b.placeholder != placeholder {
+		b.err = ErrDifferentPlaceholders
+	}
+	b.args = append(b.args, arg)
 }
 
 // argument is a wrapper for arguments passed to [Builder.Appendf].
@@ -60,14 +63,12 @@ func (a *argument) Format(s fmt.State, v rune) {
 		fmt.Fprint(s, a.value)
 
 	case '$': // PostgreSQL
-		a.builder.args = append(a.builder.args, a.value)
-		a.builder.placeholders[v] = struct{}{}
+		a.builder.appendArg(a.value, v)
 		a.builder.counter++
 		fmt.Fprintf(s, "$%d", a.builder.counter)
 
 	case '?': // MySQL/SQLite
-		a.builder.args = append(a.builder.args, a.value)
-		a.builder.placeholders[v] = struct{}{}
+		a.builder.appendArg(a.value, v)
 		fmt.Fprint(s, "?")
 
 	default:

--- a/builq_test.go
+++ b/builq_test.go
@@ -1,6 +1,7 @@
 package builq_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/cristalhq/builq"
@@ -12,6 +13,14 @@ func TestBuilder(t *testing.T) {
 		b.Appendf("SELECT * FROM %v", "users")
 		if _, _, err := b.Build(); err == nil {
 			t.Errorf("want an error")
+		}
+	})
+
+	t.Run("different placeholders", func(t *testing.T) {
+		var b builq.Builder
+		b.Appendf("WHERE foo = %$ AND bar = %?", 1, 2)
+		if _, _, err := b.Build(); !errors.Is(err, builq.ErrDifferentPlaceholders) {
+			t.Errorf("got %v; want %v", err, builq.ErrDifferentPlaceholders)
 		}
 	})
 }

--- a/example_test.go
+++ b/example_test.go
@@ -12,7 +12,7 @@ func ExampleQuery1() {
 	var b builq.Builder
 	b.Appendf("SELECT %s FROM %s", "foo, bar", "users")
 	b.Appendf("WHERE active IS TRUE")
-	b.Appendf("AND user_id = %a OR user = %a", 42, "root")
+	b.Appendf("AND user_id = %$ OR user = %$", 42, "root")
 	query, args, _ := b.Build()
 
 	fmt.Printf("query:\n%v", query)
@@ -29,11 +29,11 @@ func ExampleQuery1() {
 }
 
 func ExampleQuery2() {
-	b := builq.NewIterBuilder("$")
+	var b builq.Builder
 	b.Appendf("SELECT %s FROM %s", "foo, bar", "users")
 	b.Appendf("WHERE")
-	b.Appendf("active = %a", true)
-	b.Appendf("AND user_id = %a", 42)
+	b.Appendf("active = %$", true)
+	b.Appendf("AND user_id = %$", 42)
 	b.Appendf("ORDER BY created_at")
 	b.Appendf("LIMIT 100;")
 	query, _, _ := b.Build()
@@ -53,7 +53,7 @@ func ExampleQuery3() {
 	var b builq.Builder
 	b.Appendf("SELECT * FROM foo")
 	b.Appendf("WHERE active IS TRUE")
-	b.Appendf("AND user_id = %a", 42)
+	b.Appendf("AND user_id = %$", 42)
 	b.Appendf("LIMIT 100;")
 	query, _, _ := b.Build()
 
@@ -69,9 +69,9 @@ func ExampleQuery3() {
 func ExampleQuery4() {
 	args := []any{42, time.Now(), "just testing"}
 
-	b := builq.NewStaticBuilder("?")
+	var b builq.Builder
 	b.Appendf("INSERT (%s) INTO %s", getColumns(), "table")
-	b.Appendf("VALUES (%a, %a, %a);", args...) // TODO(junk1tm): should %a support slices?
+	b.Appendf("VALUES (%?, %?, %?);", args...) // TODO(junk1tm): should %a support slices?
 	query, _, _ := b.Build()
 
 	fmt.Println(query)


### PR DESCRIPTION
This change replaces generic `%a` placeholder with database-specific ones like `%$` and `%?`, so there is no more need for the `NewXXXBuilder` constructors.