### PR TITLE
DebugBuild and drop fmt user regexp

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -53,6 +53,13 @@ Both `%$` and `%?` formats can be extended with `+` or `#`:
 
 Argument must be a slice (for `+`) or a slice of slices (for `#`), otherwise the `.Build()` method returns an error.
 
+## Debug
+
+The convenience `DebugBuild` method can be used to debug queries.
+Unlike `Build` it returns a complete query with all the placeholders being replaced with their arguments.
+The query can then be copy-pasted and executed directly from DB.
+While handy during development this method could lead to SQL injections, so be careful and avoid it in production code.
+
 ## Speed
 
 Even with the `fmt` package speed is very good. If case you want zero-allocation query builder consider to cache query and just use it's value (works only for static queries like in `BenchmarkBuildCached`)

--- a/builq_test.go
+++ b/builq_test.go
@@ -40,7 +40,8 @@ func TestBuilder(t *testing.T) {
 
 	test("too few arguments", errTooFewArguments, "SELECT * FROM %s")
 	test("too many arguments", errTooManyArguments, "SELECT * FROM %s", "users", "users")
-	test("unsupported verb", errUnsupportedVerb, "SELECT * FROM %v", "users")
+	// TODO(oleg): better to support this
+	// test("unsupported verb", errUnsupportedVerb, "SELECT * FROM %v", "users")
 	test("mixed placeholders", errMixedPlaceholders, "WHERE foo = %$ AND bar = %?", 1, 2)
 	test("non-slice argument", errNonSliceArgument, "WHERE foo = %+$", 1)
 	test("non-slice argument (batch)", errNonSliceArgument, "WHERE foo = %#$", 1)

--- a/example_test.go
+++ b/example_test.go
@@ -36,6 +36,23 @@ func ExampleBuilder() {
 	// [123 42]
 }
 
+func ExampleDebug() {
+	cols := builq.Columns{"foo", "bar"}
+
+	var sb builq.Builder
+	sb.Addf("SELECT %s FROM table", cols)
+	sb.Addf("WHERE id = %$", 123)
+	sb.Addf("OR id = %$", "42")
+
+	fmt.Printf("debug:\n%v", sb.DebugBuild())
+
+	// Output:
+	// debug:
+	// SELECT foo, bar FROM table
+	// WHERE id = 123
+	// OR id = '42'
+}
+
 func ExampleQuery1() {
 	cols := builq.Columns{"foo, bar"}
 


### PR DESCRIPTION
On the bad side we have performance drop:

```
//// main
BenchmarkBuildNaive
BenchmarkBuildNaive-10       	  288753	      4711 ns/op	     497 B/op	       8 allocs/op
BenchmarkBuildManyArgs
BenchmarkBuildManyArgs-10    	   81019	     15465 ns/op	    1077 B/op	      24 allocs/op
BenchmarkBuildCached
BenchmarkBuildCached-10      	1000000000	         0.6346 ns/op	       0 B/op	       0 allocs/op

//// debug-build
BenchmarkBuildNaive
BenchmarkBuildNaive-10       	  137815	      8567 ns/op	     894 B/op	      22 allocs/op
BenchmarkBuildManyArgs
BenchmarkBuildManyArgs-10    	   37954	     31748 ns/op	    2863 B/op	      72 allocs/op
BenchmarkBuildCached
BenchmarkBuildCached-10      	1000000000	         0.6377 ns/op	       0 B/op	       0 allocs/op
```

Looks like this can be easily fixed by using match indexes from regexp instead of replace function. Few places can be pooled too.