### PR TITLE
DebugBuild and faster version

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -53,6 +53,13 @@ Both `%$` and `%?` formats can be extended with `+` or `#`:
 
 Argument must be a slice (for `+`) or a slice of slices (for `#`), otherwise the `.Build()` method returns an error.
 
+## Debug
+
+The convenience `DebugBuild` method can be used to debug queries.
+Unlike `Build` it returns a complete query with all the placeholders being replaced with their arguments.
+The query can then be copy-pasted and executed directly from DB.
+While handy during development this method could lead to SQL injections, so be careful and avoid it in production code.
+
 ## Speed
 
 Even with the `fmt` package speed is very good. If case you want zero-allocation query builder consider to cache query and just use it's value (works only for static queries like in `BenchmarkBuildCached`)

--- a/builq.go
+++ b/builq.go
@@ -31,8 +31,8 @@ type Builder struct {
 	err         error // the first error occurred while building the query.
 	counter     int   // a counter for numbered placeholders ($1, $2, ...).
 	placeholder rune  // a placeholder used to build the query.
-	sep         byte
-	debug       bool
+	sep         byte  // a separator between Addf calls.
+	debug       bool  // is it DebugBuild call to fill with args.
 }
 
 // OnelineBuilder behaves like Builder but result is 1 line.

--- a/example_test.go
+++ b/example_test.go
@@ -52,6 +52,23 @@ func ExampleOnelineBuilder() {
 	// SELECT foo, bar FROM table WHERE id = $1
 }
 
+func ExampleBuilder_DebugBuild() {
+	cols := builq.Columns{"foo", "bar"}
+
+	var sb builq.Builder
+	sb.Addf("SELECT %s FROM table", cols)
+	sb.Addf("WHERE id = %$", 123)
+	sb.Addf("OR id = %$", "42")
+
+	fmt.Printf("debug:\n%v", sb.DebugBuild())
+
+	// Output:
+	// debug:
+	// SELECT foo, bar FROM table
+	// WHERE id = 123
+	// OR id = '42'
+}
+
 func ExampleColumns() {
 	columns := builq.Columns{"id", "created_at", "value"}
 	params := []any{42, "right now", "just testing"}

--- a/write.go
+++ b/write.go
@@ -86,10 +86,6 @@ func (b *Builder) writeArg(verb byte, arg any) {
 			b.query.WriteByte('\'')
 			b.query.WriteString(arg)
 			b.query.WriteByte('\'')
-		case fmt.Stringer:
-			b.query.WriteByte('\'')
-			b.query.WriteString(arg.String())
-			b.query.WriteByte('\'')
 		default:
 			b.query.WriteString(fmt.Sprint(arg))
 		}

--- a/write.go
+++ b/write.go
@@ -80,6 +80,22 @@ func (b *Builder) writeSlice(verb byte, arg any) {
 }
 
 func (b *Builder) writeArg(verb byte, arg any) {
+	if b.debug {
+		switch arg := arg.(type) {
+		case string:
+			b.query.WriteByte('\'')
+			b.query.WriteString(arg)
+			b.query.WriteByte('\'')
+		case fmt.Stringer:
+			b.query.WriteByte('\'')
+			b.query.WriteString(arg.String())
+			b.query.WriteByte('\'')
+		default:
+			b.query.WriteString(fmt.Sprint(arg))
+		}
+		return
+	}
+
 	switch verb {
 	case 's':
 		switch arg := arg.(type) {

--- a/write.go
+++ b/write.go
@@ -1,0 +1,112 @@
+package builq
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func (b *Builder) write(s string, args ...any) error {
+	for argID := 0; ; argID++ {
+		n := strings.IndexByte(s, '%')
+		if n == -1 {
+			if argID != len(args) {
+				b.setErr(errTooManyArguments)
+			}
+
+			b.query.WriteString(s)
+			b.query.WriteByte(b.sep)
+			return nil
+		}
+
+		b.query.WriteString(s[:n])
+
+		if argID >= len(args) {
+			return errTooFewArguments
+		}
+
+		arg := args[argID]
+
+		s = s[n+1:] // skip '%'
+		switch verb := s[0]; verb {
+		case 's', '$', '?':
+			s = s[1:]
+			b.writeArg(verb, arg)
+
+		case '+', '#':
+			isBatch := verb == '#'
+			s = s[1:]
+			if len(s) < 1 {
+				// TODO: Error
+				continue
+			}
+
+			switch verb := (s[0]); verb {
+			case '$', '?':
+				s = s[1:]
+
+				if isBatch {
+					b.writeBatch(verb, arg)
+				} else {
+					b.writeSlice(verb, arg)
+				}
+			default:
+				b.setErr(errUnsupportedVerb)
+			}
+		default:
+			b.setErr(errUnsupportedVerb)
+		}
+	}
+}
+
+func (b *Builder) writeBatch(verb byte, arg any) {
+	for i, arg := range b.asSlice(arg) {
+		if i > 0 {
+			b.query.WriteString(", ")
+		}
+		b.query.WriteByte('(')
+		b.writeSlice(verb, arg)
+		b.query.WriteByte(')')
+	}
+}
+
+func (b *Builder) writeSlice(verb byte, arg any) {
+	for i, arg := range b.asSlice(arg) {
+		if i > 0 {
+			b.query.WriteString(", ")
+		}
+		b.writeArg(verb, arg)
+	}
+}
+
+func (b *Builder) writeArg(verb byte, arg any) {
+	switch verb {
+	case 's':
+		switch arg := arg.(type) {
+		case string:
+			b.query.WriteString(arg)
+		case fmt.Stringer:
+			b.query.WriteString(arg.String())
+		default:
+			fmt.Fprint(&b.query, arg)
+		}
+	case '$':
+		b.counter++
+		b.query.WriteByte('$')
+		b.query.WriteString(strconv.Itoa(b.counter))
+		b.args = append(b.args, arg)
+	case '?':
+		b.query.WriteByte('?')
+		b.args = append(b.args, arg)
+	}
+
+	// store the first placeholder used in the query
+	// to check for mixed placeholders later
+	// ignore 's' because it's ok to have in any case
+	if b.placeholder == 0 && verb != 's' {
+		b.placeholder = rune(verb)
+	}
+	if verb != 's' && b.placeholder != rune(verb) {
+		b.setErr(errMixedPlaceholders)
+	}
+}


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/cristalhq/builq
                 │   old.txt    │               new.txt                │
                 │    sec/op    │    sec/op     vs base                │
BuildSimple-10      499.0n ± 0%    297.6n ± 2%  -40.34% (p=0.000 n=10)
BuildManyArgs-10   1964.5n ± 1%    661.6n ± 0%  -66.32% (p=0.000 n=10)
BuildCached-10     0.6219n ± 0%   0.6266n ± 1%   +0.76% (p=0.004 n=10)
geomean             84.79n         49.79n       -41.28%

                 │    old.txt     │                new.txt                 │
                 │      B/op      │     B/op      vs base                  │
BuildSimple-10       492.0 ± 0%       864.0 ± 0%  +75.61% (p=0.000 n=10)
BuildManyArgs-10   1.040Ki ± 0%     1.188Ki ± 0%  +14.18% (p=0.000 n=10)
BuildCached-10       0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
geomean                         ²                 +26.10%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                 │   old.txt    │               new.txt                │
                 │  allocs/op   │ allocs/op   vs base                  │
BuildSimple-10     8.000 ± 0%     7.000 ± 0%  -12.50% (p=0.000 n=10)
BuildManyArgs-10   24.00 ± 0%     14.00 ± 0%  -41.67% (p=0.000 n=10)
BuildCached-10     0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
geomean                       ²               -20.08%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```