### PR TITLE
Add handy Q helper

### DIFF
--- a/builq.go
+++ b/builq.go
@@ -38,6 +38,11 @@ type OnelineBuilder struct {
 	Builder
 }
 
+// Q is a handy helper. Works as [NewOnline] and [Build] in one call.
+func Q(format constString, args ...any) (query string, resArgs []any, err error) {
+	return NewOneline()(format, args...).Build()
+}
+
 // BuildFn represents [Builder.Addf]. Just for the easier BuilderFunc declaration.
 type BuildFn func(format constString, args ...any) *Builder
 

--- a/example_test.go
+++ b/example_test.go
@@ -8,6 +8,26 @@ import (
 	"github.com/cristalhq/builq"
 )
 
+func ExampleQ() {
+	cols := builq.Columns{"foo, bar"}
+
+	query, args, err := builq.Q("SELECT %s FROM %s WHERE id = %$", cols, "users", 123)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println("query:")
+	fmt.Println(query)
+	fmt.Println("args:")
+	fmt.Println(args)
+
+	// Output:
+	// query:
+	// SELECT foo, bar FROM users WHERE id = $1
+	// args:
+	// [123]
+}
+
 func ExampleNew() {
 	cols := builq.Columns{"foo, bar"}
 


### PR DESCRIPTION
Another option is to call it `B` for `build` but `Q` for the `query` sounds good too.