### PR TITLE
Fix trim last separator

### DIFF
--- a/builq.go
+++ b/builq.go
@@ -125,11 +125,8 @@ func (b *Builder) build() (_ string, _ []any) {
 		b.setErr(err)
 	}
 
-	// drop last separator for clarity.
-	q := query.String()
-	if q[len(q)-1] == b.sep {
-		q = q[:len(q)-1]
-	}
+	// drop last separators for clarity.
+	q := strings.TrimRight(query.String(), string(b.sep))
 	return q, resArgs
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -56,7 +56,6 @@ func ExampleNew() {
 	// SELECT foo, bar FROM users
 	// WHERE active IS TRUE
 	// AND user_id = $1 OR user = $2
-	//
 	// args:
 	// [42 root]
 	// debug:


### PR DESCRIPTION
Edge case for `builq.New()`, there was 2 separators at the end.